### PR TITLE
Added blank space before MessagePrefix for fixing Color not working.

### DIFF
--- a/RetakesAllocatorCore/Config/Configs.cs
+++ b/RetakesAllocatorCore/Config/Configs.cs
@@ -218,6 +218,9 @@ public record ConfigData
     public bool EnableNextRoundTypeVoting { get; set; } = false;
     public int NumberOfExtraVipChancesForPreferredWeapon { get; set; } = 1;
     public bool AllowPreferredWeaponForEveryone { get; set; } = false;
+
+    public double RatioOfPreferredWeaponPerRound { get; set; } = 50;
+
     public Dictionary<CsTeam, int> MaxPreferredWeaponsPerTeam { get; set; } = new()
     {
         {CsTeam.Terrorist, 1},

--- a/RetakesAllocatorCore/Config/Configs.cs
+++ b/RetakesAllocatorCore/Config/Configs.cs
@@ -219,7 +219,7 @@ public record ConfigData
     public int NumberOfExtraVipChancesForPreferredWeapon { get; set; } = 1;
     public bool AllowPreferredWeaponForEveryone { get; set; } = false;
 
-    public double RatioOfPreferredWeaponPerRound { get; set; } = 50;
+    public double PercentageOfPreferredWeaponPerRound { get; set; } = 50;
 
     public Dictionary<CsTeam, int> MaxPreferredWeaponsPerTeam { get; set; } = new()
     {

--- a/RetakesAllocatorCore/OnRoundPostStartHelper.cs
+++ b/RetakesAllocatorCore/OnRoundPostStartHelper.cs
@@ -3,6 +3,7 @@ using CounterStrikeSharp.API.Modules.Utils;
 using RetakesAllocatorCore.Config;
 using RetakesAllocatorCore.Db;
 using RetakesAllocatorCore.Managers;
+using System;
 
 namespace RetakesAllocatorCore;
 
@@ -58,7 +59,11 @@ public class OnRoundPostStartHelper
 
         ICollection<T> tPreferredPlayers = new List<T>();
         ICollection<T> ctPreferredPlayers = new List<T>();
-        if (roundType == RoundType.FullBuy)
+
+        Random random = new Random();
+        double generatedChance = random.NextDouble() * 100;
+
+        if (roundType == RoundType.FullBuy && generatedChance <= Configs.GetConfigData().RatioOfPreferredWeaponPerRound)
         {
             tPreferredPlayers =
                 WeaponHelpers.SelectPreferredPlayers(FilterByPreferredWeaponPreference(tPlayers), isVip,

--- a/RetakesAllocatorCore/OnRoundPostStartHelper.cs
+++ b/RetakesAllocatorCore/OnRoundPostStartHelper.cs
@@ -63,7 +63,7 @@ public class OnRoundPostStartHelper
         Random random = new Random();
         double generatedChance = random.NextDouble() * 100;
 
-        if (roundType == RoundType.FullBuy && generatedChance <= Configs.GetConfigData().RatioOfPreferredWeaponPerRound)
+        if (roundType == RoundType.FullBuy && generatedChance <= Configs.GetConfigData().PercentageOfPreferredWeaponPerRound)
         {
             tPreferredPlayers =
                 WeaponHelpers.SelectPreferredPlayers(FilterByPreferredWeaponPreference(tPlayers), isVip,

--- a/RetakesAllocatorCore/PluginInfo.cs
+++ b/RetakesAllocatorCore/PluginInfo.cs
@@ -18,7 +18,8 @@ public static class PluginInfo
             {
                 if (Configs.GetConfigData().ChatMessagePluginPrefix is not null)
                 {
-                    return Translator.Color(Configs.GetConfigData().ChatMessagePluginPrefix!);
+                    // If message starts with color code it wont work. Hacky fix.
+                    return " " + Translator.Color(Configs.GetConfigData().ChatMessagePluginPrefix!);
                 }
 
                 name = Configs.GetConfigData().ChatMessagePluginName;


### PR DESCRIPTION
When setting ChatMessagePluginPrefix in config, If you start with color tags it won't work. Messages should not start with color  tag. 

For example config below will not be colored.

```
"ChatMessagePluginPrefix": "[GREEN] aaaaaa [NORMAL] ",
```

But if you do this way it will be colored

```
"ChatMessagePluginPrefix": "a[GREEN] aaaaaa [NORMAL] ",
```

This can be fixed by user by putting a space on config but as seen in Issue #131 it can be hard to find out what causes this.

I fixed it by putting a small space by default on code. It looks good in game too.

![awp](https://github.com/yonilerner/cs2-retakes-allocator/assets/10609922/8ccf0507-977a-46c4-b6f4-2f354dbf1bb8)
