### PR TITLE
Added blank space before MessagePrefix for fixing Color not working.

### DIFF
--- a/RetakesAllocatorCore/PluginInfo.cs
+++ b/RetakesAllocatorCore/PluginInfo.cs
@@ -18,7 +18,8 @@ public static class PluginInfo
             {
                 if (Configs.GetConfigData().ChatMessagePluginPrefix is not null)
                 {
-                    return Translator.Color(Configs.GetConfigData().ChatMessagePluginPrefix!);
+                    // If message starts with color code it wont work. Hacky fix.
+                    return " " + Translator.Color(Configs.GetConfigData().ChatMessagePluginPrefix!);
                 }
 
                 name = Configs.GetConfigData().ChatMessagePluginName;


### PR DESCRIPTION
When setting ChatMessagePluginPrefix in config, If you start with color tags it won't work. Messages should not start with color  tag. 

For example config below will not be colored.

```
"ChatMessagePluginPrefix": "[GREEN] aaaaaa [NORMAL] ",
```

But if you do this way it will be colored

```
"ChatMessagePluginPrefix": "a[GREEN] aaaaaa [NORMAL] ",
```

This can be fixed by user by putting a space on config but as seen in Issue #131 it can be hard to find out what causes this.

I fixed it by putting a small space by default on code. It looks good in game too.

![awp](https://github.com/yonilerner/cs2-retakes-allocator/assets/10609922/8ccf0507-977a-46c4-b6f4-2f354dbf1bb8)
