### PR TITLE
Added slash commands to default command config.

### DIFF
--- a/RetakesAllocatorCore/Config/Configs.cs
+++ b/RetakesAllocatorCore/Config/Configs.cs
@@ -238,8 +238,8 @@ public record ConfigData
     public LogLevel LogLevel { get; set; } = LogLevel.Information;
     public string ChatMessagePluginName { get; set; } = "Retakes";
     public string? ChatMessagePluginPrefix { get; set; }
-    public string InGameGunMenuCenterCommands { get; set; } = "gunsmenu,gunmenu,!gunmenu,!gunsmenu,!menugun,!menuguns";
-    public string InGameGunMenuChatCommands { get; set; } = "guns,!guns";
+    public string InGameGunMenuCenterCommands { get; set; } = "gunsmenu,gunmenu,!gunmenu,!gunsmenu,!menugun,!menuguns,/gunsmenu,/gunmenu";
+    public string InGameGunMenuChatCommands { get; set; } = "guns,!guns,/guns";
     public ZeusPreference ZeusPreference { get; set; } = ZeusPreference.Never;
 
     public DatabaseProvider DatabaseProvider { get; set; } = DatabaseProvider.Sqlite;


### PR DESCRIPTION
Since this plugin checks users messages instead of built in command system it does not automatically detects slash commands. I have added slash command variants to config for prevent this issue. Issue #128 should be solved by this.