### PR TITLE
Command System Remake

### DIFF
--- a/RetakesAllocator/Menus/AdvancedGunMenu.cs
+++ b/RetakesAllocator/Menus/AdvancedGunMenu.cs
@@ -43,42 +43,7 @@ public class AdvancedGunMenu
             buttonPressed.Add(playerid, false);
         }
     }
-    /*public HookResult OnEventPlayerChat(EventPlayerChat @event, GameEventInfo info)
-    {
-        if(string.IsNullOrEmpty(Configs.GetConfigData().InGameGunMenuCenterCommands) || @event == null)return HookResult.Continue;
-        var eventplayer = @event.Userid;
-        var eventmessage = @event.Text;
-        var player = Utilities.GetPlayerFromUserid(eventplayer);
-        
-        if (player == null || !player.IsValid)return HookResult.Continue;
-        var playerid = player.SteamID;
-
-        if (string.IsNullOrWhiteSpace(eventmessage)) return HookResult.Continue;
-        string trimmedMessageStart = eventmessage.TrimStart();
-        string message = trimmedMessageStart.TrimEnd();
-        string[] CenterMenuCommands = Configs.GetConfigData().InGameGunMenuCenterCommands.Split(',');
-
-        if (CenterMenuCommands.Any(cmd => cmd.Equals(message, StringComparison.OrdinalIgnoreCase)))
-        {
-            if (!menuon.ContainsKey(playerid))
-            {
-                menuon.Add(playerid, true);
-            }
-            if (!mainmenu.ContainsKey(playerid))
-            {
-                mainmenu.Add(playerid, 0);
-            }
-            if (!currentIndexDict.ContainsKey(playerid))
-            {
-                currentIndexDict.Add(playerid, 0);
-            }
-            if (!buttonPressed.ContainsKey(playerid))
-            {
-                buttonPressed.Add(playerid, false);
-            }
-        }
-        return HookResult.Continue;
-    }*/
+   
 
     public void OnTick()
     {

--- a/RetakesAllocator/Menus/AdvancedGunMenu.cs
+++ b/RetakesAllocator/Menus/AdvancedGunMenu.cs
@@ -17,7 +17,33 @@ public class AdvancedGunMenu
     public Dictionary<ulong, int> currentIndexDict = new Dictionary<ulong, int>();
     public Dictionary<ulong, bool> buttonPressed = new Dictionary<ulong, bool>();
 
-    public HookResult OnEventPlayerChat(EventPlayerChat @event, GameEventInfo info)
+
+    public void HandleMenuCommand(int eventplayer)
+    {
+
+        var player = Utilities.GetPlayerFromUserid(eventplayer);
+
+        if (player == null || !player.IsValid) return;
+        var playerid = player.SteamID;
+
+        if (!menuon.ContainsKey(playerid))
+        {
+            menuon.Add(playerid, true);
+        }
+        if (!mainmenu.ContainsKey(playerid))
+        {
+            mainmenu.Add(playerid, 0);
+        }
+        if (!currentIndexDict.ContainsKey(playerid))
+        {
+            currentIndexDict.Add(playerid, 0);
+        }
+        if (!buttonPressed.ContainsKey(playerid))
+        {
+            buttonPressed.Add(playerid, false);
+        }
+    }
+    /*public HookResult OnEventPlayerChat(EventPlayerChat @event, GameEventInfo info)
     {
         if(string.IsNullOrEmpty(Configs.GetConfigData().InGameGunMenuCenterCommands) || @event == null)return HookResult.Continue;
         var eventplayer = @event.Userid;
@@ -52,7 +78,7 @@ public class AdvancedGunMenu
             }
         }
         return HookResult.Continue;
-    }
+    }*/
 
     public void OnTick()
     {

--- a/RetakesAllocator/RetakesAllocator.cs
+++ b/RetakesAllocator/RetakesAllocator.cs
@@ -74,6 +74,50 @@ public class RetakesAllocator : BasePlugin
         {
             HandleHotReload();
         }
+
+        if (!string.IsNullOrEmpty(Configs.GetConfigData().InGameGunMenuChatCommands))
+        {
+            string[] ChatMenuCommands = Configs.GetConfigData().InGameGunMenuChatCommands.Split(',');
+            if (ChatMenuCommands.Length > 0)
+            {
+                foreach (var command in ChatMenuCommands)
+                {
+                    AddCommand($"css_{command}", "Opens the gun menu", (player, commandInfo) =>
+                    {
+                        if (player == null || !player.IsValid)
+                        {
+                            return;
+                        }
+
+                        _menuManager.OpenMenuForPlayer(player!, MenuType.Guns);
+                    });
+                }
+            }
+
+            string[] InGameGunMenuCenterCommands = Configs.GetConfigData().InGameGunMenuCenterCommands.Split(',');
+            if (InGameGunMenuCenterCommands.Length > 0)
+            {
+                foreach (var command in InGameGunMenuCenterCommands)
+                {
+                    AddCommand($"css_{command}", "Opens the advanced gun menu", (player, commandInfo) =>
+                    {
+                        if (player == null || !player.IsValid)
+                        {
+                            return;
+                        }
+
+                        _advancedGunMenu.HandleMenuCommand(player.UserId.Value);
+                    });
+                }
+            }
+
+
+            
+
+        }
+
+
+        
     }
 
     private void ResetState(bool loadConfig = true)
@@ -623,33 +667,6 @@ public class RetakesAllocator : BasePlugin
     public HookResult OnEventPlayerDisconnect(EventPlayerDisconnect @event, GameEventInfo info)
     {
         _advancedGunMenu.OnEventPlayerDisconnect(@event, info);
-        return HookResult.Continue;
-    }
-
-    [GameEventHandler(HookMode.Post)]
-    public HookResult OnEventPlayerChat(EventPlayerChat @event, GameEventInfo info)
-    {
-        if (@event == null) return HookResult.Continue;
-        _advancedGunMenu.OnEventPlayerChat(@event, info);
-
-        if (string.IsNullOrEmpty(Configs.GetConfigData().InGameGunMenuChatCommands)) return HookResult.Continue;
-        var eventplayer = @event.Userid;
-        var eventmessage = @event.Text;
-        var player = Utilities.GetPlayerFromUserid(eventplayer);
-
-        if (player == null || !player.IsValid) return HookResult.Continue;
-        var playerid = player.SteamID;
-
-        if (string.IsNullOrWhiteSpace(eventmessage)) return HookResult.Continue;
-        string trimmedMessageStart = eventmessage.TrimStart();
-        string message = trimmedMessageStart.TrimEnd();
-        string[] ChatMenuCommands = Configs.GetConfigData().InGameGunMenuChatCommands.Split(',');
-
-        if (ChatMenuCommands.Any(cmd => cmd.Equals(message, StringComparison.OrdinalIgnoreCase)))
-        {
-            _menuManager.OpenMenuForPlayer(player!, MenuType.Guns);
-        }
-
         return HookResult.Continue;
     }
 

--- a/RetakesAllocatorCore/Config/Configs.cs
+++ b/RetakesAllocatorCore/Config/Configs.cs
@@ -238,8 +238,8 @@ public record ConfigData
     public LogLevel LogLevel { get; set; } = LogLevel.Information;
     public string ChatMessagePluginName { get; set; } = "Retakes";
     public string? ChatMessagePluginPrefix { get; set; }
-    public string InGameGunMenuCenterCommands { get; set; } = "gunsmenu,gunmenu,!gunmenu,!gunsmenu,!menugun,!menuguns,/gunsmenu,/gunmenu";
-    public string InGameGunMenuChatCommands { get; set; } = "guns,!guns,/guns";
+    public string InGameGunMenuCenterCommands { get; set; } = "gunsmenu,gunmenu,menugun,menuguns";
+    public string InGameGunMenuChatCommands { get; set; } = "guns";
     public ZeusPreference ZeusPreference { get; set; } = ZeusPreference.Never;
 
     public DatabaseProvider DatabaseProvider { get; set; } = DatabaseProvider.Sqlite;

--- a/RetakesAllocatorCore/Config/Configs.cs
+++ b/RetakesAllocatorCore/Config/Configs.cs
@@ -238,8 +238,8 @@ public record ConfigData
     public LogLevel LogLevel { get; set; } = LogLevel.Information;
     public string ChatMessagePluginName { get; set; } = "Retakes";
     public string? ChatMessagePluginPrefix { get; set; }
-    public string InGameGunMenuCenterCommands { get; set; } = "gunsmenu,gunmenu,!gunmenu,!gunsmenu,!menugun,!menuguns";
-    public string InGameGunMenuChatCommands { get; set; } = "guns,!guns";
+    public string InGameGunMenuCenterCommands { get; set; } = "gunsmenu,gunmenu,!gunmenu,!gunsmenu,!menugun,!menuguns,/gunsmenu,/gunmenu";
+    public string InGameGunMenuChatCommands { get; set; } = "guns,!guns,/guns";
     public ZeusPreference ZeusPreference { get; set; } = ZeusPreference.Never;
 
     public DatabaseProvider DatabaseProvider { get; set; } = DatabaseProvider.Sqlite;


### PR DESCRIPTION
I have removed player chat event based command system and integrated it to CS# command system. By doing this players can change prefix of command by CS# settings and no need to add different prefixes to this plugin config.

Since this is a big change. Server owners should configure their config by new default config. 

Waiting your feedbacks. 