### PR TITLE
Added Portuguese translations

### DIFF
--- a/RetakesAllocator/lang/pt-PT.json
+++ b/RetakesAllocator/lang/pt-PT.json
@@ -1,0 +1,68 @@
+{
+  "roundtype.Pistol": "Pistola",
+  "roundtype.HalfBuy": "Compra Parcial",
+  "roundtype.FullBuy": "Compra Completa",
+
+  "weapon_type.primary": "Primária",
+  "weapon_type.secondary": "Secundária",
+
+  "teams.terrorist": "Terrorista",
+  "teams.terrorist_short": "T",
+  "teams.counter_terrorist": "Contra-Terrorista",
+  "teams.counter_terrorist_short": "CT",
+
+  "announcement.roundtype": "Ronda {0}",
+  "announcement.next_roundtype_set": "A próxima ronda será uma ronda de {0}.",
+  "announcement.next_roundtype_set_invalid": "Tipo de ronda inválido: {0}.",
+
+  "weapon_preference.cannot_choose": "Os jogadores não podem escolher as suas armas neste servidor.",
+  "weapon_preference.gun_usage": "Use: !gun <gun>. Correspondências parciais para qualquer arma serão encontradas.\nArmas válidas para {0}:\nPistolas: {1}\nCompra parcial: {2}\nCompra completa: {3}",
+  "weapon_preference.invalid_team": "Equipa fornecida inválida: {0}.",
+  "weapon_preference.join_team": "Deves juntar-te a uma equipa antes de executar este comando.",
+  "weapon_preference.not_found": "Arma '{0}' não encontrada.",
+  "weapon_preference.not_allowed": "Não é permitido selecionar a arma '{0}'.",
+  "weapon_preference.invalid_weapon": "Arma inválida: '{0}'.",
+  "weapon_preference.not_valid_for_team": "A arma '{0}' não é válida para {1}.",
+  "weapon_preference.unset_preference_preferred": "Já não vais receber '{0}'.",
+  "weapon_preference.unset_preference": "A arma '{0}' já não é a tua preferência de {1} para {2}.",
+  "weapon_preference.set_preference_preferred": "Agora vais receber um '{0}' quando for a tua vez de ser sniper.",
+  "weapon_preference.set_preference": "A arma '{0}' é agora a tua preferência de {1} para {2}.",
+  "weapon_preference.receive_next_round": " Vais recebê-la na próxima ronda de {0}.",
+  "weapon_preference.not_saved": "Sem um STEAM ID válido, as tuas preferências não serão guardadas.",
+  "weapon_preference.only_vip_can_use": "Só os jogadores VIP podem usar este comando!",
+
+  "menu.timeout": "Não interagiste com o menu em {0} segundos!",
+  "menu.exit": "Sair",
+  "menu.already_in_menu": "Já estás a usar outro menu!",
+
+  "vote_menu.select_vote": "Seleciona o teu voto!",
+
+  "guns_menu.invalid_steam_id": "Não podes definir preferências de armas com um STEAM ID inválido.",
+  "guns_menu.complete": "Terminaste de configurar as tuas armas!\nAs armas que selecionaste ser-te-ão entregues no início da próxima ronda!",
+  "guns_menu.select_weapon": "Seleciona uma arma {0} {1}",
+  "guns_menu.weapon_selected": "Selecionaste {0} como arma {1} {2}!",
+  "guns_menu.awp_menu": "Seleciona quando receber a AWP",
+  "guns_menu.awp_always": "Sempre",
+  "guns_menu.awp_never": "Nunca",
+  "guns_menu.awp_preference_selected": "Selecionaste '{0}' para receber a AWP!",
+
+  "menu.main.tloadout": "█ Loadout T █",
+  "menu.main.ctloadout": "█ Loadout CT █",
+  "menu.main.awp": "█ AWP █",
+
+  "menu.tprimary": "█ Primária T █",
+  "menu.tsecondary": "█ Secundária T █",
+  "menu.tPistol": "█ Ronda de Pistola T █",
+
+  "menu.ctprimary": "█ Primária CT █",
+  "menu.ctsecondary": "█ Secundária CT █",
+  "menu.ctPistol": "█ Ronda de Pistola CT █",
+
+  "menu.awp.always": "Sempre",
+  "menu.awp.never": "Nunca",
+
+  "menu.left.image": "<img src='https://raw.githubusercontent.com/yonilerner/cs2-retakes-allocator/main/Resources/left.gif' class=''>",
+  "menu.right.image": "<img src='https://raw.githubusercontent.com/yonilerner/cs2-retakes-allocator/main/Resources/right.gif' class=''>",
+  "menu.bottom.text": "<br>           <font color='cyan'>[ WASD - Para Mover ]</font> <br><font color='purple'>[ <img src='https://raw.githubusercontent.com/yonilerner/cs2-retakes-allocator/main/Resources/tab.gif' class=''> - Para Sair ]<br>",
+  "menu.bottom.text.pistol": "<font color='purple'>[ <img src='https://raw.githubusercontent.com/yonilerner/cs2-retakes-allocator/main/Resources/tab.gif' class=''> - Para Sair ]<br>"
+}


### PR DESCRIPTION
Key Changes:
- "Ronda" instead of "Rodada" (common in European Portuguese).
- Adjusted verb forms and sentence structures to match European Portuguese standards.
- Minor grammatical adjustments to ensure correct usage in European Portuguese.