### PR TITLE
update: remove 2 hardcoded sigs & exec cfg on diff roundTypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ riderModule.iml
 .vs/
 .vs-code/
 data.db
+*.sln

--- a/RetakesAllocator/CustomGameData.cs
+++ b/RetakesAllocator/CustomGameData.cs
@@ -11,22 +11,6 @@ public class CustomGameData
     {
         // Thank you to @Whaliin https://github.com/CS2Plugins/WeaponRestrict/blob/main/WeaponRestrict.json
         {
-            "CCSPlayer_ItemServices_CanAcquire",
-            new()
-            {
-		{OSPlatform.Windows, @"\x48\x8B\xC4\x44\x89\x40\x??\x48\x89\x50\x??\x48\x89\x48"},
-		{OSPlatform.Linux, @"\x55\x48\x89\xE5\x41\x57\x41\x56\x41\x55\x49\x89\xCD\x41\x54\x53\x48\x83\xEC"},
-            }
-        },
-        {
-            "GetCSWeaponDataFromKey",
-            new()
-            {
-                {OSPlatform.Windows, @"\x48\x89\x5C\x24\x??\x48\x89\x74\x24\x??\x57\x48\x83\xEC\x??\x48\x8B\xFA\x8B\xF1\x48\x85\xD2\x0F\x84"},
-                {OSPlatform.Linux, @"\x55\x48\x89\xE5\x41\x57\x41\x56\x41\x89\xFE\x41\x55\x41\x54\x45"},
-			}
-        },
-        {
             "GiveNamedItem2",
             new()
             {
@@ -46,15 +30,13 @@ public class CustomGameData
 
     public readonly
         MemoryFunctionWithReturn<CCSPlayer_ItemServices, CEconItemView, AcquireMethod, NativeObject, AcquireResult>
-        CCSPlayer_ItemServices_CanAcquireFunc;
+        CCSPlayer_ItemServices_CanAcquireFunc = new(GameData.GetSignature("CCSPlayer_ItemServices_CanAcquire"));
 
-    public readonly MemoryFunctionWithReturn<int, string, CCSWeaponBaseVData> GetCSWeaponDataFromKeyFunc;
+    public readonly MemoryFunctionWithReturn<int, string, CCSWeaponBaseVData> GetCSWeaponDataFromKeyFunc = new(GameData.GetSignature("GetCSWeaponDataFromKey"));
 
     public CustomGameData()
     {
         GiveNamedItem2 = new(GetCustomGameDataKey("GiveNamedItem2"));
-        CCSPlayer_ItemServices_CanAcquireFunc = new(GetCustomGameDataKey("CCSPlayer_ItemServices_CanAcquire"));
-        GetCSWeaponDataFromKeyFunc = new(GetCustomGameDataKey("GetCSWeaponDataFromKey"));
     }
 
     private string GetCustomGameDataKey(string key)

--- a/RetakesAllocator/RetakesAllocator.cs
+++ b/RetakesAllocator/RetakesAllocator.cs
@@ -632,6 +632,25 @@ public class RetakesAllocator : BasePlugin
         RoundTypeManager.Instance.SetCurrentRoundType(currentRoundType);
         RoundTypeManager.Instance.SetNextRoundTypeOverride(null);
 
+        switch(currentRoundType)
+        {
+            case RoundType.Pistol:
+            {
+                Server.ExecuteCommand("execifexists cs2-retakes/Pistol.cfg");
+                break;
+            }
+            case RoundType.HalfBuy:
+            {
+                Server.ExecuteCommand("execifexists cs2-retakes/SmallBuy.cfg");
+                break;
+            }
+            case RoundType.FullBuy:
+            {
+                Server.ExecuteCommand("execifexists cs2-retakes/FullBuy.cfg");
+                break;
+            }
+        }
+
         if (Configs.GetConfigData().EnableRoundTypeAnnouncement)
         {
             var roundType = RoundTypeManager.Instance.GetCurrentRoundType()!.Value;


### PR DESCRIPTION
- `CCSPlayer_ItemServices_CanAcquire` & `GetCSWeaponDataFromKey` no longer hardcoded. It is taken from default `gamedata.json` given with CounterStrikeSharp.
- Exec CFGs on different roundTypes.